### PR TITLE
added getUTF8Width method for U8g2 fonts

### DIFF
--- a/src/GxFont_GFX.cpp
+++ b/src/GxFont_GFX.cpp
@@ -65,6 +65,11 @@ void GxFont_GFX::setFont(const uint8_t *font)
   _U8G2_FONTS_GFX.setFont(font);
 }
 
+int16_t GxFont_GFX::getUTF8Width(const char *str)
+{
+ return _U8G2_FONTS_GFX.getUTF8Width(str);
+}
+
 #endif
 
 #if defined(_ADAFRUIT_TF_GFX_H_)

--- a/src/GxFont_GFX.h
+++ b/src/GxFont_GFX.h
@@ -42,6 +42,7 @@ class GxFont_GFX : public Adafruit_GFX
     void setFont(const GFXfont *f = NULL);
 #if defined(U8g2_for_Adafruit_GFX_h)
     void setFont(const uint8_t *font); // set u8g2 font
+    int16_t getUTF8Width(const char *str);
 #endif
 #if defined(_ADAFRUIT_TF_GFX_H_)
     void setFont(uint8_t f);


### PR DESCRIPTION
Hi!
(For my own needs) I added a getUTF8Width(const char *str) method to get text width if U8g2 fonts are used.
Pretty straightforward and no big deal - I didn't bother posting in the forum etc., I hope that's okay.
Thanks for the great library! Works like a charm for me.